### PR TITLE
Fix cycling self reference

### DIFF
--- a/packages/npm/deep-equal/index.js
+++ b/packages/npm/deep-equal/index.js
@@ -1,3 +1,3 @@
 'use strict'
 
-module.exports = require('deep-equal')
+module.exports = require('socket-deep-equal-orig')

--- a/packages/npm/deep-equal/package.json
+++ b/packages/npm/deep-equal/package.json
@@ -33,7 +33,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "deep-equal": "2.2.3"
+    "socket-deep-equal-orig": "npm:deep-equal@2.2.3"
   },
   "overrides": {
     "array-buffer-byte-length": "npm:@socketregistry/array-buffer-byte-length@^1",


### PR DESCRIPTION
When deep-equal is overridden with the @socketregistry/deep-equal, it gets installed in node_modules as deep-equal, but it requires deep-equal. When the original deep-equal is hoisted above the override, the override resolves back to itself creating a cycle.